### PR TITLE
temporarily comment out changelog gen

### DIFF
--- a/.github/workflows/tag-changelog-create-release.yaml
+++ b/.github/workflows/tag-changelog-create-release.yaml
@@ -15,11 +15,11 @@ jobs:
       with:
         tags: true
 
-    - name: Generate Changelog
-      id: changelog
-      uses: mikepenz/release-changelog-builder-action@v4.2.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # - name: Generate Changelog
+    #   id: changelog
+    #   uses: mikepenz/release-changelog-builder-action@v4.2.0
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Bump Version
       id: bump_version


### PR DESCRIPTION
# Overview

Temporarily removes the changelog generation so that the tag and release will be created.